### PR TITLE
Update special make target for Make 4.3

### DIFF
--- a/makefile-executor.el
+++ b/makefile-executor.el
@@ -100,7 +100,7 @@ Bindings in `makefile-mode':
 ;; Based on http://stackoverflow.com/a/26339924/983746
 (defvar makefile-executor-list-target-code
   (format
-   ".PHONY: %s\n%s:\n	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ \"^[#.]\") {print $$1}}' | sort | grep -E -v -e '^[^[:alnum:]]' -e '^$@$$'\n"
+   ".PHONY: %s\n%s:\n	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/(^|\\n)# Files(\\n|$$)/,/(^|\\n)# Finished Make data base/ {if ($$1 !~ \"^[#.]\") {print $$1}}' | sort | grep -E -v -e '^[^[:alnum:]]' -e '^$@$$'\n"
    makefile-executor-special-target makefile-executor-special-target)
   "Target used to list all other Makefile targets.")
 


### PR DESCRIPTION
Make 4.3, which comes with Ubuntu 22.04, changes the formatting of the Make data base, which breaks the package. The original command from stackoverflow ([here](http://stackoverflow.com/a/26339924/983746)) was updated to add compatibility with Make 4.3. So I just updated the command. _Edit:_ The original code breaks if you have both make 4.3 and implicit rules.